### PR TITLE
Fix file related logic

### DIFF
--- a/src/importer/_util.ts
+++ b/src/importer/_util.ts
@@ -2,7 +2,8 @@ import * as cp from "child_process";
 
 type FileType =
     | "yaml"
-    | "markdown";
+    | "yml"
+    | "md";
 
 type MarkerType =
     | "ImporterMarker"

--- a/src/importer/update.ts
+++ b/src/importer/update.ts
@@ -15,7 +15,7 @@ export async function update(outputChannel: vscode.OutputChannel) {
 
     let result: string;
     try {
-        result = await execShell(`importrer update ${fileName}`);
+        result = await execShell(`importer update ${fileName}`);
     } catch (e) {
         const errorDetail = e as string;
         outputChannel.appendLine(`${timestamp}: ${errorDetail}`);

--- a/src/importer/wrap.ts
+++ b/src/importer/wrap.ts
@@ -19,17 +19,15 @@ function wrapWithMarkers(outputChannel: vscode.OutputChannel, markerType: Marker
 
     if (!isRangeValid(startLine, endLine, textEditor)) { return; }
 
-    outputChannel.appendLine(`${timestamp}: start ${startLine}, end ${endLine}`);
-
     let text = textEditor.document.getText(lines);
     if (text === "") { return; }
     if (!text.endsWith("\n")) { text += "\n"; }
 
-    const fileType = textEditor.document.languageId;
+    const fileExtension = textEditor.document.fileName.split('.').pop();;
 
     outputChannel.appendLine(`${timestamp}: ${text}`);
 
-    textEditor.insertSnippet(snippet(fileType as FileType, markerType, text), lines);
+    textEditor.insertSnippet(snippet(fileExtension as FileType, markerType, text), lines);
 }
 
 function snippet(fileType: FileType, markerType: MarkerType, wrappedText: string): vscode.SnippetString {
@@ -61,13 +59,14 @@ function snippet(fileType: FileType, markerType: MarkerType, wrappedText: string
     let tmpl: string;
     switch (fileType) {
         case "yaml":
+        case "yml":
             const precedingWhitespace = wrappedText.search(/\S|$/);
             tmpl =
                 `${' '.repeat(precedingWhitespace)}# == ${head(markerType)}: \${1:name} / begin ${options(markerType)}==\n` +
                 `${wrappedText}` +
                 `${' '.repeat(precedingWhitespace)}# == ${head(markerType)}: \${1:name} / end ==\n`;
             return new vscode.SnippetString(tmpl);
-        case "markdown":
+        case "md":
             tmpl =
                 `<!-- == ${head(markerType)}: \${1:name} / begin == -->\n` +
                 `${wrappedText}` +


### PR DESCRIPTION
Fixed

- Helm Charts to be treated as "YAML" file, as Importer only cares about the comment style of the underlying filetype. The current approach of taking the file extension may be too simple, but should suffice for the basic use cases.
- Corrected the importer binary name which was updated to force failure for debugging.