### PR TITLE
Fix up importer and exporter marker edits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -751,10 +751,16 @@
       "dev": true
     },
     "node_modules/chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -920,9 +926,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -2037,9 +2043,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
       "dev": true,
       "dependencies": {
         "uc.micro": "^1.0.1"
@@ -2101,14 +2107,14 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
       "dev": true,
       "dependencies": {
-        "argparse": "^1.0.7",
-        "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       },
@@ -2116,20 +2122,14 @@
         "markdown-it": "bin/markdown-it.js"
       }
     },
-    "node_modules/markdown-it/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/markdown-it/node_modules/entities": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/mdurl": {
       "version": "1.0.1",
@@ -2220,32 +2220,32 @@
       "dev": true
     },
     "node_modules/mocha": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-      "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.1.tgz",
+      "integrity": "sha512-T7uscqjJVS46Pq1XDXyo9Uvey9gd3huT/DD9cYBb4K2Xc/vbKRPUWK067bxDQRK0yIz6Jxk73IrnimvASzBNAQ==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.2",
-        "debug": "4.3.2",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.1.7",
+        "glob": "7.2.0",
         "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.25",
+        "nanoid": "3.2.0",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "workerpool": "6.1.5",
+        "workerpool": "6.2.0",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
@@ -2260,26 +2260,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mochajs"
-      }
-    },
-    "node_modules/mocha/node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha/node_modules/ms": {
@@ -2316,9 +2296,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -2963,9 +2943,9 @@
       ]
     },
     "node_modules/simple-get": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
       "dev": true,
       "dependencies": {
         "decompress-response": "^4.2.0",
@@ -2981,12 +2961,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -3303,9 +3277,9 @@
       "dev": true
     },
     "node_modules/vsce": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.3.0.tgz",
-      "integrity": "sha512-nmbczr1rC+lRikX1NYMoTFX6CqPlfk11f7LbRgdjpa6zkLNndlTtnpvOawj7NYkw5jmy+5bGHMGt4DIimZXZmg==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.7.tgz",
+      "integrity": "sha512-5dEtdi/yzWQbOU7JDUSOs8lmSzzkewBR5P122BUkmXE6A/DEdFsKNsg2773NGXJTwwF1MfsOgUR6QVF3cLLJNQ==",
       "dev": true,
       "dependencies": {
         "azure-devops-node-api": "^11.0.1",
@@ -3316,7 +3290,7 @@
         "hosted-git-info": "^4.0.2",
         "keytar": "^7.7.0",
         "leven": "^3.1.0",
-        "markdown-it": "^10.0.0",
+        "markdown-it": "^12.3.2",
         "mime": "^1.3.4",
         "minimatch": "^3.0.3",
         "parse-semver": "^1.1.1",
@@ -3450,9 +3424,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
@@ -4155,9 +4129,9 @@
       }
     },
     "chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
@@ -4293,9 +4267,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -5132,9 +5106,9 @@
       }
     },
     "linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
       "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
@@ -5181,31 +5155,22 @@
       }
     },
     "markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       },
       "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
         "entities": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
           "dev": true
         }
       }
@@ -5275,51 +5240,37 @@
       "dev": true
     },
     "mocha": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.3.tgz",
-      "integrity": "sha512-Xcpl9FqXOAYqI3j79pEtHBBnQgVXIhpULjGQa7DVb0Po+VzmSIK9kanAiWLHoRR/dbZ2qpdPshuXr8l1VaHCzw==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.1.tgz",
+      "integrity": "sha512-T7uscqjJVS46Pq1XDXyo9Uvey9gd3huT/DD9cYBb4K2Xc/vbKRPUWK067bxDQRK0yIz6Jxk73IrnimvASzBNAQ==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.2",
-        "debug": "4.3.2",
+        "chokidar": "3.5.3",
+        "debug": "4.3.3",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
-        "glob": "7.1.7",
+        "glob": "7.2.0",
         "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.25",
+        "nanoid": "3.2.0",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "workerpool": "6.1.5",
+        "workerpool": "6.2.0",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
         "ms": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5350,9 +5301,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
       "dev": true
     },
     "napi-build-utils": {
@@ -5816,9 +5767,9 @@
       "dev": true
     },
     "simple-get": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
       "dev": true,
       "requires": {
         "decompress-response": "^4.2.0",
@@ -5830,12 +5781,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "string_decoder": {
@@ -6095,9 +6040,9 @@
       "dev": true
     },
     "vsce": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.3.0.tgz",
-      "integrity": "sha512-nmbczr1rC+lRikX1NYMoTFX6CqPlfk11f7LbRgdjpa6zkLNndlTtnpvOawj7NYkw5jmy+5bGHMGt4DIimZXZmg==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-2.6.7.tgz",
+      "integrity": "sha512-5dEtdi/yzWQbOU7JDUSOs8lmSzzkewBR5P122BUkmXE6A/DEdFsKNsg2773NGXJTwwF1MfsOgUR6QVF3cLLJNQ==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^11.0.1",
@@ -6108,7 +6053,7 @@
         "hosted-git-info": "^4.0.2",
         "keytar": "^7.7.0",
         "leven": "^3.1.0",
-        "markdown-it": "^10.0.0",
+        "markdown-it": "^12.3.2",
         "mime": "^1.3.4",
         "minimatch": "^3.0.3",
         "parse-semver": "^1.1.1",
@@ -6211,9 +6156,9 @@
       "dev": true
     },
     "workerpool": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "onLanguage:markdown",
     "onCommand:importer-vscode.update",
     "onCommand:importer-vscode.purge",
-    "onCommand:importer-vscode.wrap-with-importer",
+    "onCommand:importer-vscode.insert-importer-marker",
     "onCommand:importer-vscode.wrap-with-exporter"
   ],
   "main": "./out/extension.js",
@@ -33,9 +33,9 @@
         "title": "Purge"
       },
       {
-        "command": "importer-vscode.wrap-with-importer",
+        "command": "importer-vscode.insert-importer-marker",
         "category": "Importer",
-        "title": "Wrap with Importer Marker"
+        "title": "Insert Importer Marker"
       },
       {
         "command": "importer-vscode.wrap-with-exporter",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
 import { foldImported } from './importer/fold';
+import { insertImporterMarkers } from './importer/insert';
 import { purge } from './importer/purge';
 import { update } from './importer/update';
-import { wrapWithExporterMarkers, wrapWithImporterMarkers } from './importer/wrap';
+import { wrapWithExporterMarkers } from './importer/wrap';
 
 export async function activate(context: vscode.ExtensionContext) {
 	const outputChannel = vscode.window.createOutputChannel("Importer");
@@ -10,8 +11,8 @@ export async function activate(context: vscode.ExtensionContext) {
 	const updateCmd = vscode.commands.registerCommand('importer-vscode.update', () => update(outputChannel));
 	const purgeCmd = vscode.commands.registerCommand('importer-vscode.purge', () => purge(outputChannel));
 
-	const wrapWithImproterCmd = vscode.commands.registerCommand('importer-vscode.wrap-with-importer',
-		() => wrapWithImporterMarkers(outputChannel));
+	const insertImproterMarkerCmd = vscode.commands.registerCommand('importer-vscode.insert-importer-marker',
+		() => insertImporterMarkers(outputChannel));
 	const wrapWithExproterCmd = vscode.commands.registerCommand('importer-vscode.wrap-with-exporter',
 		() => wrapWithExporterMarkers(outputChannel));
 
@@ -21,7 +22,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		updateCmd,
 		purgeCmd,
-		wrapWithImproterCmd,
+		insertImproterMarkerCmd,
 		wrapWithExproterCmd,
 		// foldImportedCmd,
 	);

--- a/src/importer/_util.ts
+++ b/src/importer/_util.ts
@@ -1,4 +1,5 @@
 import * as cp from "child_process";
+import * as vscode from 'vscode';
 
 type FileType =
     | "yaml"
@@ -8,6 +9,10 @@ type FileType =
 type MarkerType =
     | "ImporterMarker"
     | "ExporterMarker";
+
+type Logic =
+    | "Insert"
+    | "Wrap";
 
 export { FileType, MarkerType };
 
@@ -23,3 +28,48 @@ export const execShell = (cmd: string) =>
     });
 
 export const checkImporerInstalled = () => execShell("importer version").then(() => true, _ => false);
+
+export function snippet(fileType: FileType, markerType: MarkerType, wrappedText: string, logic: Logic): vscode.SnippetString {
+    // TODO: Some text blocks are hard coded here. We should be able to have 
+    //       more streamlined setup with code reuse. We may actually be able to
+    //       use Importer to pull in some file content when Importer supports
+    //       JavaScript / TypeScript.
+
+    const head = (markerType: MarkerType) => {
+        switch (markerType) {
+            case "ImporterMarker":
+                return "import";
+            case "ExporterMarker":
+                return "export";
+        }
+    };
+    const options = (markerType: MarkerType) => {
+        switch (markerType) {
+            case "ImporterMarker":
+                return "from: ${2:URL or /path/to/file}#${3:lineRange or exporterMarker} ";
+            case "ExporterMarker":
+                return "";
+        }
+    };
+
+    // Quite a bit of assumptions being made, and is going to require more
+    // extensive testing to ensure all the markers are correctly created for
+    // any code.
+    let tmpl: string;
+    switch (fileType) {
+        case "yaml":
+        case "yml":
+            const precedingWhitespace = wrappedText.search(/\S|$/);
+            tmpl =
+                `${' '.repeat(precedingWhitespace)}# == ${head(markerType)}: \${1:name} / begin ${options(markerType)}==\n` +
+                `${logic === "Wrap" ? wrappedText : ""}` +
+                `${' '.repeat(precedingWhitespace)}# == ${head(markerType)}: \${1:name} / end ==\n`;
+            return new vscode.SnippetString(tmpl);
+        case "md":
+            tmpl =
+                `<!-- == ${head(markerType)}: \${1:name} / begin == -->\n` +
+                `${logic === "Wrap" ? wrappedText : ""}` +
+                `<!-- == ${head(markerType)}: \${1:name} / end == -->\n`;
+            return new vscode.SnippetString(tmpl);
+    }
+}

--- a/src/importer/insert.ts
+++ b/src/importer/insert.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+import { FileType, snippet } from './_util';
+
+export function insertImporterMarkers(outputChannel: vscode.OutputChannel) {
+    const textEditor = vscode.window.activeTextEditor;
+    if (textEditor === undefined) { return; }
+
+    const timestamp = new Date();
+    const currentLine = textEditor.selection.start.line;
+
+    outputChannel.appendLine(`${timestamp}: current line ${currentLine}`);
+
+    const current = new vscode.Range(new vscode.Position(currentLine, 0), new vscode.Position(currentLine + 1, 0));
+    let currentText = textEditor.document.getText(current);
+
+    const fileExtension = textEditor.document.fileName.split('.').pop();;
+
+    textEditor.insertSnippet(snippet(fileExtension as FileType, "ImporterMarker", currentText, "Insert"), textEditor.selection.start);
+}

--- a/src/importer/wrap.ts
+++ b/src/importer/wrap.ts
@@ -1,19 +1,17 @@
+import { start } from 'repl';
 import * as vscode from 'vscode';
-import { FileType, MarkerType } from './_util';
+import { FileType, snippet } from './_util';
 
-export const wrapWithImporterMarkers =
-    (outputChannel: vscode.OutputChannel) => wrapWithMarkers(outputChannel, "ImporterMarker");
-export const wrapWithExporterMarkers =
-    (outputChannel: vscode.OutputChannel) => wrapWithMarkers(outputChannel, "ExporterMarker");
-
-function wrapWithMarkers(outputChannel: vscode.OutputChannel, markerType: MarkerType) {
+export function wrapWithExporterMarkers(outputChannel: vscode.OutputChannel) {
     const textEditor = vscode.window.activeTextEditor;
     if (textEditor === undefined) { return; }
 
     const timestamp = new Date();
     const startLine = textEditor.selection.start.line,
         endLine = textEditor.selection.end.line,
-        lines = new vscode.Range(new vscode.Position(startLine, 0), new vscode.Position(endLine + 1, 0));
+        endChar = textEditor.selection.end.character;
+
+    const lines = getLineRange(startLine, endLine, endChar);
 
     outputChannel.appendLine(`${timestamp}: start ${startLine}, end ${endLine}`);
 
@@ -27,56 +25,18 @@ function wrapWithMarkers(outputChannel: vscode.OutputChannel, markerType: Marker
 
     outputChannel.appendLine(`${timestamp}: ${text}`);
 
-    textEditor.insertSnippet(snippet(fileExtension as FileType, markerType, text), lines);
+    textEditor.insertSnippet(snippet(fileExtension as FileType, "ExporterMarker", text, "Wrap"), lines);
 }
 
-function snippet(fileType: FileType, markerType: MarkerType, wrappedText: string): vscode.SnippetString {
-    // TODO: Some text blocks are hard coded here. We should be able to have 
-    //       more streamlined setup with code reuse. We may actually be able to
-    //       use Importer to pull in some file content when Importer supports
-    //       JavaScript / TypeScript.
+function getLineRange(startLine: number, endLine: number, endChar: number): vscode.Range {
+    if (startLine === endLine) { return new vscode.Range(new vscode.Position(startLine, 0), new vscode.Position(endLine + 1, 0)); }
+    if (endLine > startLine && endChar === 0) { return new vscode.Range(new vscode.Position(startLine, 0), new vscode.Position(endLine, 0)); }
 
-    const head = (markerType: MarkerType) => {
-        switch (markerType) {
-            case "ImporterMarker":
-                return "import";
-            case "ExporterMarker":
-                return "export";
-        }
-    };
-    const options = (markerType: MarkerType) => {
-        switch (markerType) {
-            case "ImporterMarker":
-                return "from: ${2:URL or /path/to/file}#${3:lineRange or exporterMarker} ";
-            case "ExporterMarker":
-                return "";
-        }
-    };
-
-    // Quite a bit of assumptions being made, and is going to require more
-    // extensive testing to ensure all the markers are correctly created for
-    // any code.
-    let tmpl: string;
-    switch (fileType) {
-        case "yaml":
-        case "yml":
-            const precedingWhitespace = wrappedText.search(/\S|$/);
-            tmpl =
-                `${' '.repeat(precedingWhitespace)}# == ${head(markerType)}: \${1:name} / begin ${options(markerType)}==\n` +
-                `${wrappedText}` +
-                `${' '.repeat(precedingWhitespace)}# == ${head(markerType)}: \${1:name} / end ==\n`;
-            return new vscode.SnippetString(tmpl);
-        case "md":
-            tmpl =
-                `<!-- == ${head(markerType)}: \${1:name} / begin == -->\n` +
-                `${wrappedText}` +
-                `<!-- == ${head(markerType)}: \${1:name} / end == -->\n`;
-            return new vscode.SnippetString(tmpl);
-    }
+    return new vscode.Range(new vscode.Position(startLine, 0), new vscode.Position(endLine + 1, 0));
 }
 
 function isRangeValid(startLine: number, endLine: number, textEditor: vscode.TextEditor): boolean {
-    if (startLine === 0 || endLine === 0) { return false; }
+    // if (startLine === 0 && endLine === 0 ) { return false; }
     if (startLine > endLine) { return false; }
 
     return true;


### PR DESCRIPTION
Fixed

- Exporter Marker wrapping to handle the line difference, and correctly select only the lines that are selected

Updated

- "Wrap with Importer Marker" has been replaced by "Insert Importer Marker", as Importer Marker usage often wouldn't need to wrap an existing data